### PR TITLE
Release 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ Initial release of code count tool, support
 
 ## TODO
 
-* [ ] fix: when open a huge project, there should have a progress, like clangd
+* [x] fix: when open a huge project, there should have a progress, like clangd
 * [x] fix: when we faliure on a certain file, or when we get stuck on certain file, we should print some log to help debug
 * [ ] add a new command to generate a report of the whole project
 * [ ] add support for golang
 * [ ] add support for rust
-* [ ] fix a bug: in file counter, we may not open a file, just check and ignore it
-* [ ] fix: failed to parse empty ipynb
+* [x] add support for gdscript
+* [x] fix a bug: in file counter, we may not open a file, just check and ignore it
+* [x] fix: failed to parse empty ipynb, empty ipynb is a empty file, which is a special case, we could handle it specifically
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,12 @@ Initial release of code count tool, support
 ## TODO
 
 * [ ] fix: when open a huge project, there should have a progress, like clangd
-* [ ] fix: when we faliure on a certain file, or when we get stuck on certain file, we should print some log to help debug
+* [x] fix: when we faliure on a certain file, or when we get stuck on certain file, we should print some log to help debug
 * [ ] add a new command to generate a report of the whole project
 * [ ] add support for golang
 * [ ] add support for rust
 * [ ] fix a bug: in file counter, we may not open a file, just check and ignore it
+* [ ] fix: failed to parse empty ipynb
 
 ---
 

--- a/src/analyzer/py-analyzer.ts
+++ b/src/analyzer/py-analyzer.ts
@@ -6,6 +6,13 @@ import { LineClass } from "../common/types";
 import { Analyzer } from "./base-analyzer";
 
 function extractCodesFromIpynb({ text }: { text: string }): string {
+  // first check if if file is empty
+  // cause empty ipynb is a valid ipynb, but its content is an empty file
+  text = text.trim();
+  if (text === "") {
+    return "";
+  }
+
   const ipynb = JSON.parse(text);
   // we may be parse error
   // in that case, we just raise an error

--- a/src/analyzer/py-analyzer.ts
+++ b/src/analyzer/py-analyzer.ts
@@ -7,6 +7,8 @@ import { Analyzer } from "./base-analyzer";
 
 function extractCodesFromIpynb({ text }: { text: string }): string {
   const ipynb = JSON.parse(text);
+  // we may be parse error
+  // in that case, we just raise an error
 
   const codes: string[] = [];
   for (const cell of ipynb.cells) {

--- a/src/counter/file-counter.ts
+++ b/src/counter/file-counter.ts
@@ -6,6 +6,7 @@ import * as fs from "fs/promises";
 import { newAnalyzer } from "../analyzer/factory";
 import { SupportedLanguage } from "../common/supported-languages";
 import { FileResult } from "../common/types";
+import { printToChannelOutput } from "../lib/output-channel";
 
 export class FileCounter {
   private language: SupportedLanguage;
@@ -23,12 +24,28 @@ export class FileCounter {
   }
 
   async countFile(): Promise<FileResult | undefined> {
-    const text = await fs.readFile(this.absolutePath, { encoding: "utf8" });
+    try {
+      printToChannelOutput(`Start counting: ${this.absolutePath}`);
+      const text = await fs.readFile(this.absolutePath, { encoding: "utf8" });
 
-    return newAnalyzer({
-      text,
-      language: this.language,
-      absolutePath: this.absolutePath,
-    })?.analyze();
+      // 应该在这里添加日志吧
+      // 之后读取已经分析好的结果，也不需要日志啊
+      // 而且不管是最开是的count workspace 还是之后的save file update file 都是走这个
+      // console.log(`Start counting: ${this.absolutePath}`);
+
+      const result = newAnalyzer({
+        text,
+        language: this.language,
+        absolutePath: this.absolutePath,
+      })?.analyze();
+      // console.log(`End counting: ${this.absolutePath}`);
+      printToChannelOutput(`End counting: ${this.absolutePath}`);
+      return result;
+    } catch (error) {
+      // console.error(`Error counting file: ${this.absolutePath}`);
+      // console.error(error);
+      printToChannelOutput(`Failed counting: ${this.absolutePath}`);
+      return undefined;
+    }
   }
 }

--- a/src/counter/folder-counter.ts
+++ b/src/counter/folder-counter.ts
@@ -4,6 +4,7 @@
 import { SupportedLanguage } from "../common/supported-languages";
 import { FolderResult } from "../common/types";
 import { filterManager } from "../filter/filter-manager";
+import { getLoadingStatusBarItem } from "../lib/loading-status-bar-item";
 
 import { FileCounter } from "./file-counter";
 
@@ -30,21 +31,52 @@ export class FolderCounter {
       workspacePath: this.workspacePath,
     });
 
-    for (const absolutePath of await filter.getFilteredFiles({
+    // https://stackoverflow.com/questions/55633453/rotating-octicon-in-statusbar-of-vs-code
+    // there is a loading icon in vscode icons
+    // and a spin operator can spin it, we are loading!
+    // now the problem is that we need show the loading status bar
+    // the eaist way to do this is create a new status bar item
+    // and only show it when we count the workspace
+    // and we show the other status bar item when we finish counting
+    // this status bar item is better to write as a single module
+
+    // almost right
+    // Code Counting: 1234 rest
+    const loadingStatusBarItem = getLoadingStatusBarItem();
+    loadingStatusBarItem.show();
+
+    // collecting files first
+    loadingStatusBarItem.text = `$(loading~spin) code-count: collecting files of ${this.language}`;
+    const filteredFiles = await filter.getFilteredFiles({
       workspacePath: this.workspacePath,
       language: this.language,
-    })) {
+    });
+
+    let totalFilesCount = filteredFiles.length;
+    loadingStatusBarItem.text = `$(loading~spin) code-count: ${totalFilesCount} file(s) remains`;
+
+    for (const absolutePath of filteredFiles) {
       const fileCounter = new FileCounter({
         language: this.language,
         absolutePath,
       });
 
       const fileResult = await fileCounter.countFile();
-      if (fileResult === undefined) {
-        continue;
+      if (fileResult !== undefined) {
+        // now this contnue is not correct
+        // continue;
+        this.folderResult[absolutePath] = fileResult;
       }
-      this.folderResult[absolutePath] = fileResult;
+
+      // update too frequently is not good
+      // how to update the text more smoothly and interestingly?
+      if (totalFilesCount % 10 === 0) {
+        loadingStatusBarItem.text = `$(loading~spin) code-count: ${totalFilesCount} file(s) remains`;
+      }
+      totalFilesCount -= 1;
     }
+
+    loadingStatusBarItem.hide();
     return this.folderResult;
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import {
 import { LineClass, FileResult } from "./common/types";
 import { WorkspaceCounter } from "./counter/workspace-counter";
 import { filterManager } from "./filter/filter-manager";
+import { registerLoadingStatusBarItem } from "./lib/loading-status-bar-item";
 import {
   activateOutputChannel,
   disposeOutputChannel,
@@ -67,7 +68,12 @@ export async function activate({ subscriptions }: vscode.ExtensionContext) {
   statusBarItem.tooltip = new vscode.MarkdownString(
     "# Count Codes And Comments\n- The beginning icon is standing for the language of the current file.\n- In Codes: x/y, x means the lines of codes in the current file, y means the total lines of codes that belongs to the same langugae in the current workspcae.\n- Annos: x/y means the lines of comments in the current file and the current workspace.\n # Toggle Background Color\n- Click to toggle the background color in the current file to check codes and comments line by line.",
   );
+  // TODO: all the resource should add to subscriptions
+  // When you add disposables to the subscriptions array, Visual Studio Code will automatically dispose of them when the extension is deactivated, ensuring that resources are properly released and preventing memory leaks.
   subscriptions.push(statusBarItem);
+
+  // add loading status bar item
+  subscriptions.push(registerLoadingStatusBarItem());
 
   // This event is fired when the active text editor changes
   // This can happen when a new editor is opened, an existing editor is brought into focus,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,10 @@ import {
 import { LineClass, FileResult } from "./common/types";
 import { WorkspaceCounter } from "./counter/workspace-counter";
 import { filterManager } from "./filter/filter-manager";
+import {
+  activateOutputChannel,
+  disposeOutputChannel,
+} from "./lib/output-channel";
 
 let statusBarItem: vscode.StatusBarItem;
 let workspaceCounter = new WorkspaceCounter();
@@ -47,6 +51,9 @@ export async function activate({ subscriptions }: vscode.ExtensionContext) {
       updateStatusBarItem();
     }),
   );
+
+  // Create the Output Channel
+  activateOutputChannel("Code Count");
 
   // create a new status bar item that will show at the right end of the status bar
   statusBarItem = vscode.window.createStatusBarItem(
@@ -132,6 +139,10 @@ export async function activate({ subscriptions }: vscode.ExtensionContext) {
       });
     }),
   );
+}
+
+export function deactivate() {
+  disposeOutputChannel();
 }
 
 const lookFile = async (uri: vscode.Uri) => {

--- a/src/lib/loading-status-bar-item.ts
+++ b/src/lib/loading-status-bar-item.ts
@@ -1,0 +1,21 @@
+// 2024/9/19
+// zhangzhong
+
+// eslint-disable-next-line import/no-unresolved
+import * as vscode from "vscode";
+
+let loadingStatusBarItem: vscode.StatusBarItem;
+
+export function registerLoadingStatusBarItem(): vscode.StatusBarItem {
+  loadingStatusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Left,
+    10,
+  );
+  // loadingStatusBarItem.text = "$(loading~spin) Code Counting...";
+  // loadingStatusBarItem.tooltip = "Loading...";
+  return loadingStatusBarItem;
+}
+
+export function getLoadingStatusBarItem(): vscode.StatusBarItem {
+  return loadingStatusBarItem;
+}

--- a/src/lib/output-channel.ts
+++ b/src/lib/output-channel.ts
@@ -1,0 +1,32 @@
+// 2024/9/19
+// zhangzhong
+
+// eslint-disable-next-line import/no-unresolved
+import * as vscode from "vscode";
+
+let outputChannel: vscode.OutputChannel;
+
+export const activateOutputChannel = (name: string): void => {
+  // https://code.visualstudio.com/api/references/vscode-api#OutputChannel
+  outputChannel = vscode.window.createOutputChannel(name);
+};
+
+export const disposeOutputChannel = (): void => {
+  // Clean up resources if necessary
+  if (outputChannel) {
+    outputChannel.dispose();
+  }
+};
+
+/**
+ * Prints the given content on the output channel.
+ *
+ * @param content The content to be printed.
+ * @param reveal Whether the output channel should be revealed.
+ */
+export const printToChannelOutput = (content: string, reveal = false): void => {
+  outputChannel.appendLine(content);
+  if (reveal) {
+    outputChannel.show(true);
+  }
+};


### PR DESCRIPTION
1. Add support of GDScript
2. Add progress status bar item when counting new workspace folder
3. Fix a bug that could stuck the extension when counting a file with a correct suffix but which is a folder, such as a folder names: example.cpp
4. Fix a bug that failed to counting an empty Jupyter notebook